### PR TITLE
IP Rate limits

### DIFF
--- a/user_conf.d/myportfolio.conf
+++ b/user_conf.d/myportfolio.conf
@@ -8,7 +8,7 @@ server {
   }
 }
 
-limit_req_zone $binary_remote_addr zone=ip_rate_lim:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone=ip_rate_lim:10m rate=5r/s;
 
 server {
   listen 443 ssl;
@@ -20,7 +20,7 @@ server {
   }
 
   location /v2/timeline {
-    limit_req zone=ip_rate_lim;
+    limit_req zone=ip_rate_lim burst=5 nodelay;
     proxy_pass http://myportfolio:5000/v2/timeline;
   }
 


### PR DESCRIPTION
allows the app to limit the calls per ip on our timeline database.